### PR TITLE
Fix activation URL

### DIFF
--- a/DersTakipSistemi/account/urls.py
+++ b/DersTakipSistemi/account/urls.py
@@ -7,8 +7,7 @@ from django.contrib.auth import views as auth_views
 urlpatterns = [
     path('login', views.login_request, name="login"),
     path('register', views.register_request, name="register"),
-    path('activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/', activate,
-         name='activate'),
+    path('activate/<uidb64>/<token>/', activate, name='activate'),
     path('change_password', views.change_password, name="change_password"),
     path('sifre', views.sifre, name="sifre"),
     path('logout', views.logout_request, name="logout"),


### PR DESCRIPTION
## Summary
- fix activation URL regex

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python DersTakipSistemi/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684b2de232b4832a9ce45cdcaec32332